### PR TITLE
process_response_body rescue should return more meaningful tuple

### DIFF
--- a/lib/client_token.ex
+++ b/lib/client_token.ex
@@ -25,6 +25,8 @@ defmodule Braintree.ClientToken do
         {:ok, construct(client_token)}
       {:error, %{"api_error_response" => error}} ->
         {:error, Error.construct(error)}
+      {:error, _any} ->
+        {:error, Error.construct(%{"message" => "An error occurred."})}
     end
   end
 

--- a/lib/customer.ex
+++ b/lib/customer.ex
@@ -72,6 +72,8 @@ defmodule Braintree.Customer do
         {:ok, construct(customer)}
       {:error, %{"api_error_response" => error}} ->
         {:error, Error.construct(error)}
+      {:error, _any} ->
+        {:error, Error.construct(%{"message" => "An error occurred."})}
     end
   end
 
@@ -95,6 +97,8 @@ defmodule Braintree.Customer do
         {:ok, construct(customer)}
       {:error, %{"api_error_response" => error}} ->
         {:error, Error.construct(error)}
+      {:error, _any} ->
+        {:error, Error.construct(%{"message" => "An error occurred."})}
     end
   end
 

--- a/lib/payment_method.ex
+++ b/lib/payment_method.ex
@@ -34,6 +34,8 @@ defmodule Braintree.PaymentMethod do
         {:ok, PaypalAccount.construct(paypal_account)}
       {:error, %{"api_error_response" => error}} ->
         {:error, Error.construct(error)}
+      {:error, _any} ->
+        {:error, Error.construct(%{"message" => "An error occurred."})}
     end
   end
 
@@ -72,6 +74,8 @@ defmodule Braintree.PaymentMethod do
         {:error, Error.construct(error)}
       {:error, :not_found} ->
         {:error, Error.construct(%{"message" => "Token is invalid."})}
+      {:error, _any} ->
+        {:error, Error.construct(%{"message" => "An error occurred."})}
     end
   end
 
@@ -92,6 +96,8 @@ defmodule Braintree.PaymentMethod do
         {:error, Error.construct(error)}
       {:error, :not_found} ->
         {:error, Error.construct(%{"message" => "Token is invalid."})}
+      {:error, _any} ->
+        {:error, Error.construct(%{"message" => "An error occurred."})}
     end
   end
 
@@ -115,6 +121,8 @@ defmodule Braintree.PaymentMethod do
         {:error, Error.construct(error)}
       {:error, :not_found} ->
         {:error, Error.construct(%{"message" => "Token is invalid."})}
+      {:error, _any} ->
+        {:error, Error.construct(%{"message" => "An error occurred."})}
     end
   end
 end

--- a/lib/payment_method_nonce.ex
+++ b/lib/payment_method_nonce.ex
@@ -48,6 +48,8 @@ defmodule Braintree.PaymentMethodNonce do
         {:error, Error.construct(error)}
       {:error, :not_found} ->
         {:error, Error.construct(%{"message" => "Token is invalid."})}
+      {:error, _any} ->
+        {:error, Error.construct(%{"message" => "An error occurred."})}
     end
   end
 
@@ -69,6 +71,8 @@ defmodule Braintree.PaymentMethodNonce do
         {:error, Error.construct(error)}
       {:error, :not_found} ->
         {:error, Error.construct(%{"message" => "Token is invalid."})}
+      {:error, _any} ->
+        {:error, Error.construct(%{"message" => "An error occurred."})}
     end
   end
 end

--- a/lib/paypal_account.ex
+++ b/lib/paypal_account.ex
@@ -50,6 +50,8 @@ defmodule Braintree.PaypalAccount do
         {:error, Error.construct(error)}
       {:error, :not_found} ->
         {:error, Error.construct(%{"message" => "Token is invalid."})}
+      {:error, _any} ->
+        {:error, Error.construct(%{"message" => "An error occurred."})}
     end
   end
 
@@ -73,6 +75,8 @@ defmodule Braintree.PaypalAccount do
         {:error, Error.construct(error)}
       {:error, :not_found} ->
         {:error, Error.construct(%{"message" => "Token is invalid."})}
+      {:error, _any} ->
+        {:error, Error.construct(%{"message" => "An error occurred."})}
     end
   end
 
@@ -93,6 +97,8 @@ defmodule Braintree.PaypalAccount do
         {:error, Error.construct(error)}
       {:error, :not_found} ->
         {:error, Error.construct(%{"message" => "Token is invalid."})}
+      {:error, _any} ->
+        {:error, Error.construct(%{"message" => "An error occurred."})}
     end
   end
 end

--- a/lib/subscription.ex
+++ b/lib/subscription.ex
@@ -93,6 +93,8 @@ defmodule Braintree.Subscription do
         {:ok, construct(subscription)}
       {:error, %{"api_error_response" => error}} ->
         {:error, Error.construct(error)}
+      {:error, _any} ->
+        {:error, Error.construct(%{"message" => "An error occurred."})}
     end
   end
 end

--- a/lib/transaction.ex
+++ b/lib/transaction.ex
@@ -85,6 +85,8 @@ defmodule Braintree.Transaction do
         {:ok, construct(transaction)}
       {:error, %{"api_error_response" => error}} ->
         {:error, Error.construct(error)}
+      {:error, _any} ->
+        {:error, Error.construct(%{"message" => "An error occurred."})}
     end
   end
 
@@ -106,6 +108,8 @@ defmodule Braintree.Transaction do
         {:ok, construct(transaction)}
       {:error, %{"api_error_response" => error}} ->
         {:error, Error.construct(error)}
+      {:error, _any} ->
+        {:error, Error.construct(%{"message" => "An error occurred."})}
     end
   end
 
@@ -127,6 +131,8 @@ defmodule Braintree.Transaction do
         {:error, Error.construct(error)}
       {:error, :not_found} ->
         {:error, Error.construct(%{"message" => "Transaction ID is invalid."})}
+      {:error, _any} ->
+        {:error, Error.construct(%{"message" => "An error occurred."})}
     end
   end
 
@@ -146,6 +152,8 @@ defmodule Braintree.Transaction do
         {:error, Error.construct(error)}
       {:error, :not_found} ->
         {:error, Error.construct(%{"message" => "Transaction ID is invalid."})}
+      {:error, _any} ->
+        {:error, Error.construct(%{"message" => "An error occurred."})}
     end
   end
 end

--- a/test/http_test.exs
+++ b/test/http_test.exs
@@ -55,8 +55,8 @@ defmodule Braintree.HTTPTest do
   end
 
   test "process_response/1 converts a error status into errors" do
-    assert HTTP.process_response({:ok, %{status_code: 401}}) == {:error, :unauthorized}
-    assert HTTP.process_response({:ok, %{status_code: 404}}) == {:error, :not_found}
+    assert HTTP.process_response({:ok, %HTTPoison.Response{status_code: 401}}) == {:error, :unauthorized}
+    assert HTTP.process_response({:ok, %HTTPoison.Response{status_code: 404}}) == {:error, :not_found}
   end
 
   test "basic_auth/2 encodes credentials" do


### PR DESCRIPTION
`ErlangError -> Logger.error("unprocessable response")` this line was causing some issues. The logger returns :ok ... since there is no pattern match process_response for {:ok, :ok} we hit runtime errors.

This should fail gracefully and return a proper {:error, ErrorResponse.t} tuple for every request.
