### PR TITLE
Temporary ampersand parsing workaround

### DIFF
--- a/lib/xml/decoder.ex
+++ b/lib/xml/decoder.ex
@@ -19,7 +19,7 @@ defmodule Braintree.XML.Decoder do
 
       iex> Braintree.XML.Decoder.load("<a><b type='string'>Jos&#233;</b></a>")
       %{"a" => %{"b" => "José"}}
-      
+
       iex> Braintree.XML.Decoder.load("<a><b type='string'>First &amp; Last</b></a>")
       %{"a" => %{"b" => "First & Last"}}
   """
@@ -58,7 +58,7 @@ defmodule Braintree.XML.Decoder do
     |> Enum.reject(&(&1 == ""))
     |> List.first
   end
-  
+
   defp transform(elements) when is_list(elements),
     do: Enum.into(without_nil(elements), %{}, &transform/1)
 
@@ -86,7 +86,7 @@ defmodule Braintree.XML.Decoder do
   defp transform({name, _, values}) do
     try do
       {name, Enum.join(values, " ")}
-    rescue 
+    rescue
       _ -> {name, transform(values)}
     end
   end

--- a/lib/xml/entity.ex
+++ b/lib/xml/entity.ex
@@ -14,7 +14,7 @@ defmodule Braintree.XML.Entity do
 
       iex> Braintree.XML.Entity.decode("Normal")
       "Normal"
-      
+
       iex> Braintree.XML.Entity.decode("&amp;")
       "&amp;"
   """
@@ -22,7 +22,7 @@ defmodule Braintree.XML.Entity do
     string =
       string
       |> String.replace("&amp;", "[TEMP AMP REPLACEMENT]")
-    
+
     Regex.replace(~r/\&([^\s]+);/U, string, &replace/2)
     |> String.replace("[TEMP AMP REPLACEMENT]", "&amp;")
   end

--- a/lib/xml/entity.ex
+++ b/lib/xml/entity.ex
@@ -14,9 +14,17 @@ defmodule Braintree.XML.Entity do
 
       iex> Braintree.XML.Entity.decode("Normal")
       "Normal"
+      
+      iex> Braintree.XML.Entity.decode("&amp;")
+      "&amp;"
   """
   def decode(string) do
+    string =
+      string
+      |> String.replace("&amp;", "[TEMP AMP REPLACEMENT]")
+    
     Regex.replace(~r/\&([^\s]+);/U, string, &replace/2)
+    |> String.replace("[TEMP AMP REPLACEMENT]", "&amp;")
   end
 
   @doc """


### PR DESCRIPTION
This is a hackish workaround for the issue presented [here](https://github.com/sorentwo/braintree-elixir/issues/23)

I'm looking into other options, but basically this doesn't allow `&amp;` to be regex'd into `&` before `xmerl_scan` runs in `decoder.ex`
