### PR TITLE
REVZILLA-2541 | Add apple pay card functionality

### DIFF
--- a/lib/apple_pay_card.ex
+++ b/lib/apple_pay_card.ex
@@ -1,0 +1,43 @@
+defmodule Braintree.ApplePayCard do
+  @moduledoc """
+  Find, update and delete Cards from ApplePay Accounts using PaymentMethod token
+  """
+
+  use Braintree.Construction
+
+  @type t :: %__MODULE__{
+        bin: String.t(),
+        card_type: String.t(),
+        cardholder_name: String.t(),
+        created_at: String.t(),
+        customer_id: String.t(),
+        default?: boolean(),
+        expiration_month: String.t(),
+        expiration_year: String.t(),
+        expired?: boolean(),
+        image_url: String.t(),
+        last_4: String.t(),
+        payment_instrument_name: String.t(),
+        source_description: String.t(),
+        subscriptions: [any],
+        token: String.t(),
+        updated_at: String.t()
+  }
+
+  defstruct bin: nil,
+            card_type: nil,
+            cardholder_name: nil,
+            created_at: nil,
+            customer_id: nil,
+            default?: false,
+            expiration_month: nil,
+            expiration_year: nil,
+            expired?: false,
+            image_url: nil,
+            last_4: nil,
+            payment_instrument_name: nil,
+            source_description: nil,
+            subscriptions: [],
+            token: nil,
+            updated_at: nil
+end

--- a/lib/customer.ex
+++ b/lib/customer.ex
@@ -9,7 +9,7 @@ defmodule Braintree.Customer do
 
   use Braintree.Construction
 
-  alias Braintree.{CreditCard, HTTP, PaypalAccount, Search, VenmoAccount, AndroidPayCard}
+  alias Braintree.{CreditCard, HTTP, PaypalAccount, Search, VenmoAccount, AndroidPayCard, ApplePayCard}
   alias Braintree.ErrorResponse, as: Error
 
   @type t :: %__MODULE__{
@@ -27,6 +27,7 @@ defmodule Braintree.Customer do
           addresses: [map],
           credit_cards: [CreditCard.t()],
           android_pay_cards: [AndroidPayCard.t()],
+          apple_pay_cards: [ApplePayCard.t()],
           paypal_accounts: [PaypalAccount.t()],
           venmo_accounts: [VenmoAccount.t()],
           coinbase_accounts: [map]
@@ -46,6 +47,7 @@ defmodule Braintree.Customer do
             addresses: [],
             credit_cards: [],
             android_pay_cards: [],
+            apple_pay_cards: [],
             paypal_accounts: [],
             venmo_accounts: [],
             coinbase_accounts: []
@@ -158,6 +160,7 @@ defmodule Braintree.Customer do
       customer
       | credit_cards: CreditCard.new(customer.credit_cards),
         android_pay_cards: AndroidPayCard.new(customer.android_pay_cards),
+        apple_pay_cards: ApplePayCard.new(customer.apple_pay_cards),
         paypal_accounts: PaypalAccount.new(customer.paypal_accounts),
         venmo_accounts: VenmoAccount.new(customer.venmo_accounts)
     }

--- a/lib/payment_method.ex
+++ b/lib/payment_method.ex
@@ -4,7 +4,7 @@ defmodule Braintree.PaymentMethod do
   may be a `CreditCard` or a `PaypalAccount`.
   """
 
-  alias Braintree.{CreditCard, HTTP, PaypalAccount, VenmoAccount, AndroidPayCard}
+  alias Braintree.{CreditCard, HTTP, PaypalAccount, VenmoAccount, AndroidPayCard, ApplePayCard}
   alias Braintree.ErrorResponse, as: Error
 
   @doc """
@@ -30,6 +30,7 @@ defmodule Braintree.PaymentMethod do
           | {:ok, PaypalAccount.t()}
           | {:ok, VenmoAccount.t()}
           | {:ok, AndroidPayCard.t()}
+          | {:ok, ApplePayCard.t()}
           | {:error, Error.t()}
   def create(params \\ %{}, opts \\ []) do
     with {:ok, payload} <- HTTP.post("payment_methods", %{payment_method: params}, opts) do
@@ -66,6 +67,7 @@ defmodule Braintree.PaymentMethod do
           | {:ok, PaypalAccount.t()}
           | {:ok, VenmoAccount.t()}
           | {:ok, AndroidPayCard.t()}
+          | {:ok, ApplePayCard.t()}
           | {:error, Error.t()}
   def update(token, params \\ %{}, opts \\ []) do
     path = "payment_methods/any/" <> token
@@ -106,6 +108,7 @@ defmodule Braintree.PaymentMethod do
           | {:ok, PaypalAccount.t()}
           | {:ok, VenmoAccount.t()}
           | {:ok, AndroidPayCard.t()}
+          | {:ok, ApplePayCard.t()}
           | {:error, Error.t()}
   def find(token, opts \\ []) do
     path = "payment_methods/any/" <> token
@@ -115,7 +118,7 @@ defmodule Braintree.PaymentMethod do
     end
   end
 
-  @spec new(map) :: CreditCard.t() | PaypalAccount.t() | VenmoAccount.t() | AndroidPayCard.t()
+  @spec new(map) :: CreditCard.t() | PaypalAccount.t() | VenmoAccount.t() | AndroidPayCard.t() | ApplePayCard.t()
   defp new(%{"credit_card" => credit_card}) do
     CreditCard.new(credit_card)
   end
@@ -130,5 +133,9 @@ defmodule Braintree.PaymentMethod do
 
   defp new(%{"android_pay_card" => android_pay_card}) do
     AndroidPayCard.new(android_pay_card)
+  end
+
+  defp new(%{"apple_pay_card" => apple_pay_card}) do
+    ApplePayCard.new(apple_pay_card)
   end
 end

--- a/lib/payment_method.ex
+++ b/lib/payment_method.ex
@@ -1,7 +1,6 @@
 defmodule Braintree.PaymentMethod do
   @moduledoc """
-  Create, update, find and delete payment methods. Payment methods
-  may be a `CreditCard` or a `PaypalAccount`.
+  Create, update, find and delete payment methods.
   """
 
   alias Braintree.{CreditCard, HTTP, PaypalAccount, VenmoAccount, AndroidPayCard, ApplePayCard}


### PR DESCRIPTION
# Why

https://revzilla.atlassian.net/browse/REVZILLA-2541

Ground work for apple pay 

# What Changed

Matched the pattern for adding new method from: https://github.com/revzilla/braintree-elixir/pull/11

Using the values found here: https://developers.braintreepayments.com/reference/response/apple-pay-card/ruby