### PR TITLE
CLP-3321 Add Transaction search

### DIFF
--- a/lib/search.ex
+++ b/lib/search.ex
@@ -56,6 +56,17 @@ defmodule Braintree.Search do
     end
   end
 
+  # Credit card transaction is an odd case because path to endpoints is
+  # different from the object name in the XML.
+  defp fetch_records_chunk(ids, "transactions", initializer, opts) when is_list(ids) do
+    search_params = %{search: %{ids: ids}}
+
+    with {:ok, %{"credit_card_transactions" => data}} <-
+           HTTP.post("transactions/advanced_search", search_params, opts) do
+      initializer.(data)
+    end
+  end
+
   defp fetch_records_chunk(ids, resource, initializer, opts) when is_list(ids) do
     search_params = %{search: %{ids: ids}}
 

--- a/lib/transaction.ex
+++ b/lib/transaction.ex
@@ -10,7 +10,7 @@ defmodule Braintree.Transaction do
 
   use Braintree.Construction
 
-  alias Braintree.{AddOn, HTTP}
+  alias Braintree.{AddOn, HTTP, Search}
   alias Braintree.ErrorResponse, as: Error
 
   @type t :: %__MODULE__{
@@ -211,6 +211,22 @@ defmodule Braintree.Transaction do
     with {:ok, payload} <- HTTP.get(path, opts) do
       {:ok, new(payload)}
     end
+  end
+
+  @doc """
+  To search for transactions, pass a map of search parameters.
+
+  Braintree documentation:
+  https://docs-prod-us-east-2.production.braintree-api.com/reference/request/transaction/search/
+
+  ## Examples:
+
+      {:ok, transactions} = Braintree.Transaction.search(%{customer_phone: %{is: "1234567890"}})
+      {:ok, transactions} = Braintree.Transaction.search(%{source: ["recurring"]})
+  """
+  @spec search(map, Keyword.t()) :: {:ok, t()} | {:error, Error.t()}
+  def search(params, opts \\ []) when is_map(params) do
+    Search.perform(params, "transactions", &new/1, opts)
   end
 
   @doc """


### PR DESCRIPTION
# Why?
https://revzilla.atlassian.net/browse/CLP-3321

# What changed?
Added `Transaction.search/2`

# Dev QA
There is a monorepo PR which updates the redline dependencies to use this version of the library.

Please see this PR to do the QA: https://github.com/revzilla/monorepo/pull/4494